### PR TITLE
Adding support for SELL sparse matrix format

### DIFF
--- a/src/DeviceSparseArrays.jl
+++ b/src/DeviceSparseArrays.jl
@@ -20,7 +20,9 @@ import KernelAbstractions:
     @localmem,
     @synchronize,
     @private,
-    @uniform
+    @uniform,
+    @print,
+    @Const
 using AcceleratedKernels
 
 import Adapt
@@ -29,7 +31,10 @@ export AbstractDeviceSparseArray,
     AbstractDeviceSparseVector, AbstractDeviceSparseMatrix, AbstractDeviceSparseVecOrMat
 
 export DeviceSparseVector,
-    DeviceSparseMatrixCSC, DeviceSparseMatrixCSR, DeviceSparseMatrixCOO, DeviceSparseMatrixSELL
+    DeviceSparseMatrixCSC,
+    DeviceSparseMatrixCSR,
+    DeviceSparseMatrixCOO,
+    DeviceSparseMatrixSELL
 
 include("core.jl")
 include("helpers.jl")

--- a/src/matrix_sell.jl
+++ b/src/matrix_sell.jl
@@ -23,7 +23,7 @@ A sparse matrix stored in Sliced ELLPACK (SELL) format on a the device.
 struct DeviceSparseMatrixSELL{
     Tv,
     Ti<:Integer,
-	SlicePtrT<:AbstractVector{Ti},
+    SlicePtrT<:AbstractVector{Ti},
     ColValT<:AbstractVector{Ti},
     NzValT<:AbstractVector{Tv},
 } <: AbstractDeviceSparseMatrix{Tv,Ti}
@@ -38,7 +38,7 @@ struct DeviceSparseMatrixSELL{
     nnz::Int
     n_stored::Int
 
-    function DeviceSparseMatrixSELL{Tv, Ti, SlicePtrT, ColValT, NzValT}(
+    function DeviceSparseMatrixSELL{Tv,Ti,SlicePtrT,ColValT,NzValT}(
         m::Integer,
         n::Integer,
         slice_ptr::SlicePtrT,
@@ -48,12 +48,12 @@ struct DeviceSparseMatrixSELL{
         slice_size::Integer,
         nslices::Integer,
         nnz::Integer,
-        n_stored::Integer
+        n_stored::Integer,
         #backend::B,
     ) where {
         Tv,
         Ti,
-		SlicePtrT<:AbstractVector{Ti},
+        SlicePtrT<:AbstractVector{Ti},
         ColValT<:AbstractVector{Ti},
         NzValT<:AbstractVector{Tv},
         #B<:KernelAbstractions.Backend,
@@ -69,7 +69,8 @@ struct DeviceSparseMatrixSELL{
         _check_type(Ti, colval) || throw(ArgumentError("colval must be of type $Ti"))
         _check_type(Tv, nzval) || throw(ArgumentError("nzval must be of type $Tv"))
 
-        length(slice_ptr) == nslices + 1 || throw(ArgumentError("slice_ptr length must be nslices+1"))
+        length(slice_ptr) == nslices + 1 ||
+            throw(ArgumentError("slice_ptr length must be nslices+1"))
         length(colval) == length(nzval) ||
             throw(ArgumentError("colval and nzval must have same length"))
 
@@ -98,7 +99,7 @@ function DeviceSparseMatrixSELL(
     slice_size::Int,
     nslices::Int,
     nnz::Int,
-    n_stored::Int
+    n_stored::Int,
 ) where {
     SlicePtrT<:AbstractVector{Ti},
     ColValT<:AbstractVector{Ti},
@@ -107,17 +108,17 @@ function DeviceSparseMatrixSELL(
     Ti2 = _get_eltype(slice_ptr)
     Tv2 = _get_eltype(nzval)
     DeviceSparseMatrixSELL{Tv2,Ti2,SlicePtrT,ColValT,NzValT}(
-		m,
-		n,
-		slice_ptr,
-		colval,
-		nzval,
-		perm,
-		slice_size,
-		nslices,
-		nnz,
-		n_stored
-	)
+        m,
+        n,
+        slice_ptr,
+        colval,
+        nzval,
+        perm,
+        slice_size,
+        nslices,
+        nnz,
+        n_stored,
+    )
 end
 
 # From dense matrix
@@ -131,8 +132,11 @@ function DeviceSparseMatrixSELL(
 end
 
 # From Transposed CSC
-function DeviceSparseMatrixSELL(A::Transpose{Tv,<:SparseMatrixCSC{Tv,Ti}}, slice_size::Int = 32) where {Tv,Ti<:Integer}
-	A_csr = DeviceSparseMatrixCSR(A)
+function DeviceSparseMatrixSELL(
+    A::Transpose{Tv,<:SparseMatrixCSC{Tv,Ti}},
+    slice_size::Int = 32,
+) where {Tv,Ti<:Integer}
+    A_csr = DeviceSparseMatrixCSR(A)
     return DeviceSparseMatrixSELL(A_csr, slice_size)
 end
 
@@ -152,7 +156,7 @@ function DeviceSparseMatrixSELL(
     rowptr = m.rowptr
     colval = m.colval
     nzval = m.nzval
-    slice_size = min(slice_size, size(m, 1))
+    slice_size = iszero(size(m, 1)) ? 1 : min(slice_size, size(m, 1))
     n_slices = ceil(Int, size(m, 1) / slice_size)
     max_nnz_per_slice = zeros(Int, n_slices)
     nnz_per_row = diff(rowptr)
@@ -170,13 +174,14 @@ function DeviceSparseMatrixSELL(
         max_nnz_per_slice[i] = maximum(nnz_per_row[row_start:row_end])
         n_stored += max_nnz_per_slice[i] * slice_size
     end
-    colval_padded = zeros(Ti, n_stored)
-    nzval_padded = zeros(Tv, n_stored)
     slice_ptr = zeros(Ti, n_slices + 1)
     slice_ptr[1] = 1
     for i = 1:n_slices
         slice_ptr[i+1] = slice_ptr[i] + max_nnz_per_slice[i] * slice_size
     end
+
+    colval_padded = Vector{Ti}(undef, n_stored)
+    nzval_padded = Vector{Tv}(undef, n_stored) # zeros(Tv, n_stored) is not type stable for some reason
 
     for slice = 1:n_slices
         slice_start = (slice - 1) * slice_size + 1
@@ -185,7 +190,7 @@ function DeviceSparseMatrixSELL(
         max_nnz = max_nnz_per_slice[slice]
 
         ### Padding for vals is 0 and for col indices is -1 (invalid index)
-        temp_colval = ones(Ti, slice_size, max_nnz) .* -1
+        temp_colval = -ones(Ti, slice_size, max_nnz)
         temp_nzval = zeros(Tv, slice_size, max_nnz)
         for row = slice_start:slice_end
             if row > size(m, 1)
@@ -196,12 +201,11 @@ function DeviceSparseMatrixSELL(
             temp_colval[row-slice_start+1, 1:(end_-start+1)] = colval[start:end_]
             temp_nzval[row-slice_start+1, 1:(end_-start+1)] = nzval[start:end_]
         end
-        
         # Reshape the sub-matrix to make it column-major vector and copy it to final storage
         colval_padded[slice_ptr[slice]:(slice_ptr[slice+1]-1)] =
-            collect(Iterators.flatten(temp_colval)) # matrix -> transposed matrix -> vector with inverted dimensions
+            reshape(temp_colval, :)
         nzval_padded[slice_ptr[slice]:(slice_ptr[slice+1]-1)] =
-            collect(Iterators.flatten(temp_nzval))
+            reshape(temp_nzval, :)
     end
 
     DeviceSparseMatrixSELL(
@@ -214,22 +218,22 @@ function DeviceSparseMatrixSELL(
         slice_size,
         n_slices,
         nnz(m),
-        n_stored
+        n_stored,
     )
 
 end
 
 Adapt.adapt_structure(to, A::DeviceSparseMatrixSELL) = DeviceSparseMatrixSELL(
-	size(A, 1),
-	size(A, 2),
-	Adapt.adapt_structure(to, A.slice_ptr),
-	Adapt.adapt_structure(to, A.colval),
-	Adapt.adapt_structure(to, A.nzval),
-	A.perm,
-	A.slice_size,
-	A.nslices,
-	A.nnz,
-	A.n_stored,
+    size(A, 1),
+    size(A, 2),
+    Adapt.adapt_structure(to, A.slice_ptr),
+    Adapt.adapt_structure(to, A.colval),
+    Adapt.adapt_structure(to, A.nzval),
+    A.perm,
+    A.slice_size,
+    A.nslices,
+    A.nnz,
+    A.n_stored,
 )
 
 # Base methods for the DeviceSparseMatrixSELL type
@@ -242,44 +246,44 @@ Base.show(io::IO, A::DeviceSparseMatrixSELL) = println(
 )
 Base.display(A::DeviceSparseMatrixSELL) = show(stdout, A)
 
-function Base.collect(A::DeviceSparseMatrixSELL) 
-	slice_ptr = collect(A.slice_ptr)
-	colval = collect(A.colval)
-	nzval = collect(A.nzval)
+function Base.collect(A::DeviceSparseMatrixSELL)
+    slice_ptr = collect(A.slice_ptr)
+    colval = collect(A.colval)
+    nzval = collect(A.nzval)
 
-	m, n = size(A)
-	dense_A = zeros(eltype(nzval), m, n)
-	for slice in 1:A.nslices
-		max_nnz = (slice_ptr[slice+1] - slice_ptr[slice]) ÷ A.slice_size
-		for row in 1:A.slice_size
-			global_row = (slice-1)*A.slice_size + row
-			if global_row > m
-				break
-			end
-			for e in 1:max_nnz
-				idx = slice_ptr[slice] + (row-1) + (e-1)*A.slice_size
-				col = colval[idx]
-				if col == -1
-					break
-				end
-				val = nzval[idx]
-				dense_A[global_row, col] = val
-			end
-		end
-	end
-	return dense_A
+    m, n = size(A)
+    dense_A = zeros(eltype(nzval), m, n)
+    for slice = 1:A.nslices
+        max_nnz = (slice_ptr[slice+1] - slice_ptr[slice]) ÷ A.slice_size
+        for row = 1:A.slice_size
+            global_row = (slice-1)*A.slice_size + row
+            if global_row > m
+                break
+            end
+            for e = 1:max_nnz
+                idx = slice_ptr[slice] + (row-1) + (e-1)*A.slice_size
+                col = colval[idx]
+                if col == -1
+                    break
+                end
+                val = nzval[idx]
+                dense_A[global_row, col] = val
+            end
+        end
+    end
+    return dense_A
 end
 Base.copy(A::DeviceSparseMatrixSELL) = DeviceSparseMatrixSELL(
-	A.m,
-	A.n,
-	copy(A.slice_ptr),
-	copy(A.colval),
-	copy(A.nzval),
-	copy(A.perm),
-	A.slice_size,
-	A.nslices,
-	A.nnz,
-	A.n_stored,
+    A.m,
+    A.n,
+    copy(A.slice_ptr),
+    copy(A.colval),
+    copy(A.nzval),
+    copy(A.perm),
+    A.slice_size,
+    A.nslices,
+    A.nnz,
+    A.n_stored,
 )
 
 function Base.getindex(A::DeviceSparseMatrixSELL, i::Int, j::Int)
@@ -327,19 +331,63 @@ KernelAbstractions.get_backend(A::DeviceSparseMatrixSELL) = get_backend(A.nzval)
 
 # Linear algebra functions
 function Base.:-(A::DeviceSparseMatrixSELL)
-    return DeviceSparseMatrixSELL(A.m, A.n, copy(A.slice_ptr), copy(A.colval), -A.nzval, copy(A.perm), A.slice_size, A.nslices, A.nnz, A.n_stored)
+    return DeviceSparseMatrixSELL(
+        A.m,
+        A.n,
+        copy(A.slice_ptr),
+        copy(A.colval),
+        -A.nzval,
+        copy(A.perm),
+        A.slice_size,
+        A.nslices,
+        A.nnz,
+        A.n_stored,
+    )
 end
 Base.conj(A::DeviceSparseMatrixSELL{<:Real}) = A
 function Base.conj(A::DeviceSparseMatrixSELL{<:Complex})
-    return DeviceSparseMatrixSELL(A.m, A.n, copy(A.slice_ptr), copy(A.colval), conj.(A.nzval), copy(A.perm), A.slice_size, A.nslices, A.nnz, A.n_stored)
+    return DeviceSparseMatrixSELL(
+        A.m,
+        A.n,
+        copy(A.slice_ptr),
+        copy(A.colval),
+        conj.(A.nzval),
+        copy(A.perm),
+        A.slice_size,
+        A.nslices,
+        A.nnz,
+        A.n_stored,
+    )
 end
 Base.real(A::DeviceSparseMatrixSELL{<:Real}) = A
 function Base.real(A::DeviceSparseMatrixSELL{<:Complex})
-    return DeviceSparseMatrixSELL(A.m, A.n, copy(A.slice_ptr), copy(A.colval), real.(A.nzval), copy(A.perm), A.slice_size, A.nslices, A.nnz, A.n_stored)
+    return DeviceSparseMatrixSELL(
+        A.m,
+        A.n,
+        copy(A.slice_ptr),
+        copy(A.colval),
+        real.(A.nzval),
+        copy(A.perm),
+        A.slice_size,
+        A.nslices,
+        A.nnz,
+        A.n_stored,
+    )
 end
 Base.imag(A::DeviceSparseMatrixSELL{<:Real}) = zero(A)
 function Base.imag(A::DeviceSparseMatrixSELL{<:Complex})
-    return DeviceSparseMatrixSELL(A.m, A.n, copy(A.slice_ptr), copy(A.colval), imag.(A.nzval), copy(A.perm), A.slice_size, A.nslices, A.nnz, A.n_stored)
+    return DeviceSparseMatrixSELL(
+        A.m,
+        A.n,
+        copy(A.slice_ptr),
+        copy(A.colval),
+        imag.(A.nzval),
+        copy(A.perm),
+        A.slice_size,
+        A.nslices,
+        A.nnz,
+        A.n_stored,
+    )
 end
 function Base.:(*)(α::Number, A::DeviceSparseMatrixSELL)
     return DeviceSparseMatrixSELL(
@@ -359,7 +407,7 @@ Base.:(*)(A::DeviceSparseMatrixSELL, α::Number) = α * A
 Base.:(/)(A::DeviceSparseMatrixSELL, α::Number) = (1 / α) * A
 
 function LinearAlgebra.tr(A::DeviceSparseMatrixSELL)
-	throw(ArgumentError("Transpose of DeviceSparseMatrixSELL is not implemented yet."))
+    throw(ArgumentError("Transpose of DeviceSparseMatrixSELL is not implemented yet."))
 end
 
 @kernel function sell_spmv_kernel!(
@@ -370,9 +418,8 @@ end
     @Const(slice_size),
     @Const(n),
     @Const(b),
-	@Const(α),
-	@Const(β)
-
+    @Const(α),
+    @Const(β)
 )
     #offset, slice = @index(Global, NTuple)
     #offset = offset - 1
@@ -380,19 +427,23 @@ end
     row = @index(Global, Linear)
     slice = (row-1) ÷ slice_size + 1
     offset = (row-1) % slice_size
-    if row <= n # Necessary check for out-of-bounds threads, as the last slice go beyond n
-        start = a_slice_ptr[slice] + offset
-        stop = a_slice_ptr[slice+1] - 1
-        acc = zero(eltype(c))
-        for i = start:slice_size:stop
-            col = a_col_val[i]
-            if col == -1
-                break
-            end
-            acc += a_nz_val[i] * b[col]
+    #if row <= n 
+    start = a_slice_ptr[slice] + offset
+    stop = a_slice_ptr[slice+1] - 1
+    acc = zero(eltype(c))
+    for i = start:slice_size:stop
+        col = a_col_val[i]
+        if col == -1
+            break
         end
-        c[row] = α * acc + c[row] * β
+        acc += a_nz_val[i] * b[col]
     end
+    if β == zero(β) # avoid reading c when β == 0, as c may be uninitialized
+        c[row] = α * acc
+    else
+        c[row] = α * acc + β * c[row]
+    end
+    #end
 end
 
 function LinearAlgebra.mul!(
@@ -408,8 +459,8 @@ function LinearAlgebra.mul!(
     InputType<:Number,
     ResVec<:AbstractVector{ResType},
     InputVec<:AbstractVector{InputType},
-	T1<:Number,
-	T2<:Number,
+    T1<:Number,
+    T2<:Number,
 }
     size(A, 2) == size(B, 1) || throw(
         DimensionMismatch(
@@ -438,7 +489,7 @@ function LinearAlgebra.mul!(
     backend_A == backend_B == backend_C ||
         throw(ArgumentError("All arrays must have the same backend"))
 
-	# Call the kernel
+    # Call the kernel
     kernel! = sell_spmv_kernel!(backend_A)
     kernel!(
         C,
@@ -448,8 +499,8 @@ function LinearAlgebra.mul!(
         A.slice_size,
         A.n,
         B,
-		α,
-		β,
+        α,
+        β,
         ndrange = size(A, 1),
     )
 end
@@ -462,23 +513,26 @@ end
     @Const(a_slice_size),
     @Const(B),
     @Const(n),
-	@Const(α),
-	@Const(β)
+    @Const(α),
+    @Const(β)
 )
     # Computes A*B and stores the result in C
-    col_B_C, offset, slice = @index(Global, NTuple)
-    offset = offset - 1
-    row = (slice-1) * a_slice_size + offset + 1
+    col_B_C, row = @index(Global, NTuple)
+    offset = (row-1) % a_slice_size
+    slice = (row-1) ÷ a_slice_size + 1
     acc = zero(eltype(C))
-    if row <= n # Necessary check for out-of-bounds threads, as the last slice go beyond n
-        for i = (a_slice_ptr[slice]+offset):a_slice_size:(a_slice_ptr[slice+1]-1)
-            col_A = a_col_val[i]
-            if col_A == -1 
-                break
-            end
-            acc += a_nz_val[i] * B[col_A, col_B_C]
+    #if row <= n 
+    for i = (a_slice_ptr[slice]+offset):a_slice_size:(a_slice_ptr[slice+1]-1)
+        col_A = a_col_val[i]
+        if col_A == -1
+            break
         end
-        C[row, col_B_C] = α * acc + C[row, col_B_C] * β 
+        acc += a_nz_val[i] * B[col_A, col_B_C]
+    end
+    if β == zero(β) # avoid reading C when β == 0, as C may be uninitialized
+        C[row, col_B_C] = α * acc
+    else
+        C[row, col_B_C] = α * acc + C[row, col_B_C] * β
     end
 end
 
@@ -494,137 +548,137 @@ function LinearAlgebra.mul!(
     ResType<:Number,
     InputType<:Number,
     ResMat<:AbstractMatrix{ResType},
-	InputMat<:AbstractMatrix{InputType},
-	T1<:Number,
-	T2<:Number,
+    InputMat<:AbstractMatrix{InputType},
+    T1<:Number,
+    T2<:Number,
 }
-	size(A, 2) == size(B, 1) || throw(
-		DimensionMismatch(
-			"second dimension of A, $(size(A,2)), does not match the first dimension of B, $(size(B,1))",
-		),
-	)
-	size(A, 1) == size(C, 1) || throw(
-		DimensionMismatch(
-			"first dimension of A, $(size(A,1)), does not match the first dimension of C, $(size(C,1))",
-		),
-	)
-	size(B, 2) == size(C, 2) || throw(
-		DimensionMismatch(
-			"second dimension of B, $(size(B,2)), does not match the second dimension of C, $(size(C,2))",
-		),
-	)
-	promote_type(T1, T2, Tv, InputType) <: ResType || throw(
-		ArgumentError(
-			"element types of A, B, α, and β must be promotable to the element type of C - got $Tv, $InputType, $T1, $T2, and $(eltype(C))",
-		),
-	)
-	backend_C = get_backend(C)
-	backend_A = get_backend(A)
-	backend_B = get_backend(B)
+    size(A, 2) == size(B, 1) || throw(
+        DimensionMismatch(
+            "second dimension of A, $(size(A,2)), does not match the first dimension of B, $(size(B,1))",
+        ),
+    )
+    size(A, 1) == size(C, 1) || throw(
+        DimensionMismatch(
+            "first dimension of A, $(size(A,1)), does not match the first dimension of C, $(size(C,1))",
+        ),
+    )
+    size(B, 2) == size(C, 2) || throw(
+        DimensionMismatch(
+            "second dimension of B, $(size(B,2)), does not match the second dimension of C, $(size(C,2))",
+        ),
+    )
+    promote_type(T1, T2, Tv, InputType) <: ResType || throw(
+        ArgumentError(
+            "element types of A, B, α, and β must be promotable to the element type of C - got $Tv, $InputType, $T1, $T2, and $(eltype(C))",
+        ),
+    )
+    backend_C = get_backend(C)
+    backend_A = get_backend(A)
+    backend_B = get_backend(B)
 
-	backend_A == backend_B == backend_C ||
-		throw(ArgumentError("All arrays must have the same backend"))
+    backend_A == backend_B == backend_C ||
+        throw(ArgumentError("All arrays must have the same backend"))
 
-	# Call the kernel
-	kernel! = sell_spmm_kernel!(backend_A)
-	kernel!(
-		C,
-		A.colval,
-		A.nzval,
-		A.slice_ptr,
-		A.slice_size,
-		B,
-		A.n,
-		α,
-		β,
-		ndrange = (size(B, 2), A.slice_size, A.nslices),
-	)
-	
+    # Call the kernel
+    kernel! = sell_spmm_kernel!(backend_A)
+    kernel!(
+        C,
+        A.colval,
+        A.nzval,
+        A.slice_ptr,
+        A.slice_size,
+        B,
+        A.n,
+        α,
+        β,
+        ndrange = (size(B, 2), size(A, 1)),
+    )
+
 end
 
 function LinearAlgebra.mul!(
-	C::ResVec,
-	A::DeviceSparseMatrixSELL{Tv,Ti},
-	B::InputVec,
+    C::ResVec,
+    A::DeviceSparseMatrixSELL{Tv,Ti},
+    B::InputVec,
 ) where {
-	Tv,
-	Ti<:Integer,
-	ResType<:Number,
-	InputType<:Number,
-	ResVec<:AbstractVector{ResType},
-	InputVec<:AbstractVector{InputType},
+    Tv,
+    Ti<:Integer,
+    ResType<:Number,
+    InputType<:Number,
+    ResVec<:AbstractVector{ResType},
+    InputVec<:AbstractVector{InputType},
 }
-	return mul!(C, A, B, one(ResType), zero(ResType))
+    return mul!(C, A, B, one(ResType), zero(ResType))
 end
 
 @kernel function sell_dot_kernel!(
-	C,
+    C,
     @Const(a_col_val),
     @Const(a_nz_val),
     @Const(a_slice_ptr),
     @Const(a_slice_size),
     @Const(n),
     @Const(X),
-	@Const(Y)
+    @Const(Y)
 )
-	# Compute the product C = X * (A * Y)
-	row = @index(Global, Linear)
+    # Compute the product C = X * (A * Y)
+    row = @index(Global, Linear)
     slice = (row-1) ÷ a_slice_size + 1
     offset = (row-1) % a_slice_size
-    if row <= n # Necessary check for out-of-bounds threads, as the last slice go beyond n
-        start = a_slice_ptr[slice] + offset
-        stop = a_slice_ptr[slice+1] - 1
-        acc = zero(eltype(C))
-        for i = start:a_slice_size:stop
-            col = a_col_val[i]
-            if col == -1
-                break
-            end
-            acc += a_nz_val[i] * Y[col]
+    #if row <= n 
+    start = a_slice_ptr[slice] + offset
+    stop = a_slice_ptr[slice+1] - 1
+    acc = zero(eltype(C))
+    for i = start:a_slice_size:stop
+        col = a_col_val[i]
+        if col == -1
+            break
         end
-        C[row] = X[row] * acc
+        conj
+        acc += dot(X[row], a_nz_val[i], Y[col])
     end
-	
+    C[row] = acc
+    #end
+
 end
 
-# 3 argument dot product. TODO: make custom kernel to avoid intermediate results
+# 3 argument dot product. TODO: make reduction in kernel to avoid intermediate results
 function LinearAlgebra.dot(
-	x::AbstractVector{Tx},
-	A::DeviceSparseMatrixSELL{Tv,Ti},
-	y::AbstractVector{Ty}
-) where {Ty, Tv, Ti<:Integer, Tx}
-	# x . (A*y)
-	println("DeviceSparseMatrixSELL dot product")
-	size(A, 1) == length(x) || throw(
-		DimensionMismatch(
-			"first dimension of A, $(size(A,1)), does not match the length of x, $(length(x))",
-		),
-	)
-	size(A, 2) == length(y) || throw(
-		DimensionMismatch(
-			"second dimension of A, $(size(A,2)), does not match the length of y, $(length(y))",
-		),
-	)
-	backend_x = get_backend(x)
-	backend_A = get_backend(A)
-	backend_y = get_backend(y)
+    x::AbstractVector{Tx},
+    A::DeviceSparseMatrixSELL{Tv,Ti},
+    y::AbstractVector{Ty},
+) where {Ty,Tv,Ti<:Integer,Tx}
+    # x . (A*y)
+    size(A, 1) == length(x) || throw(
+        DimensionMismatch(
+            "first dimension of A, $(size(A,1)), does not match the length of x, $(length(x))",
+        ),
+    )
+    size(A, 2) == length(y) || throw(
+        DimensionMismatch(
+            "second dimension of A, $(size(A,2)), does not match the length of y, $(length(y))",
+        ),
+    )
+    backend_x = get_backend(x)
+    backend_A = get_backend(A)
+    backend_y = get_backend(y)
 
-	backend_A == backend_x == backend_y ||
-		throw(ArgumentError("All arrays must have the same backend"))
+    backend_A == backend_x == backend_y ||
+        throw(ArgumentError("All arrays must have the same backend"))
 
-	# Call the kernel
-	temp_res = similar(x)
-	kernel! = sell_dot_kernel!(backend_A)
-	kernel!(
-		temp_res,
-		A.colval,
-		A.nzval,
-		A.slice_ptr,
-		A.slice_size,
-		A.n,
-		x,
-		y,
-		ndrange = size(A, 1),
-	)
-	return sum(temp_res)
+    # Call the kernel
+    temp_res = similar(x)
+    kernel! = sell_dot_kernel!(backend_A)
+    kernel!(
+        temp_res,
+        A.colval,
+        A.nzval,
+        A.slice_ptr,
+        A.slice_size,
+        A.n,
+        x,
+        y,
+        ndrange = size(A, 1),
+    )
+    return sum(temp_res)
 end

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -27,4 +27,11 @@
         (Float32, Float64),
         (ComplexF32, ComplexF64),
     )
+    shared_test_matrix_sell(
+        CuArray,
+        "CUDA",
+        (Int32, Int64),
+        (Float32, Float64),
+        (ComplexF32, ComplexF64),
+    )
 end

--- a/test/metal/metal.jl
+++ b/test/metal/metal.jl
@@ -3,4 +3,5 @@
     shared_test_matrix_csc(MtlArray, "Metal", (Int32,), (Float32,), (ComplexF32,))
     shared_test_matrix_csr(MtlArray, "Metal", (Int32,), (Float32,), (ComplexF32,))
     shared_test_matrix_coo(MtlArray, "Metal", (Int32,), (Float32,), (ComplexF32,))
+    shared_test_matrix_sell(MtlArray, "Metal", (Int32,), (Float32,), (ComplexF32,))
 end

--- a/test/reactant/reactant.jl
+++ b/test/reactant/reactant.jl
@@ -27,4 +27,11 @@
         (Float32, Float64),
         (ComplexF32, ComplexF64),
     )
+    shared_test_matrix_sell(
+        Reactant.ConcreteRArray,
+        "Reactant",
+        (Int32, Int64),
+        (Float32, Float64),
+        (ComplexF32, ComplexF64),
+    )
 end

--- a/test/shared/matrix_sell.jl
+++ b/test/shared/matrix_sell.jl
@@ -56,7 +56,7 @@ function shared_test_conversion_matrix_sell(
         # TODO: add a better test for internal storage, using hardcoded expected values
         @test sum(collect(nonzeros(dB))) == sum(vals)
         @test sum(filter(x -> x != -1, collect(colvals(dB)))) == sum(B_csr_t.rowval)
-        
+
 
         @test @allowscalar SparseMatrixCSC(dB) == B
         @test @allowscalar SparseMatrixCSC(dB2) == B
@@ -72,7 +72,6 @@ function shared_test_conversion_matrix_sell(
             1,
             2,
             2,
-
         )
     end
 end
@@ -215,7 +214,7 @@ function shared_test_linearalgebra_matrix_sell(
             #    (identity, transpose, adjoint),
             #)
             for (op_A, op_B) in ((identity, identity),)
-                
+
                 dims_A = op_A === identity ? (100, 80) : (80, 100)
                 dims_B = op_B === identity ? (80, 50) : (50, 80)
 


### PR DESCRIPTION
Hi! Recently @gdalle told me he might use this package, but it is currently missing the SELL matrix format which we worked on a few months ago. I mostly copied over this from my previous repo, trying to match the design choices made in this repo. (More info on this format available in the [CuSparse documentation](https://docs.nvidia.com/cuda/cusparse/#sliced-ellpack-sell))

Here are a few points I think are worth addressing before merging:

- I had not previously implemented the 3-argument dot product. I made a "quick and dirty" version, but it is currently allocating, so it should be optimised first (probably not hard to do).
- I didn't implement the kernels for `Transpose` and `Adjoint`, and don't really have the time to do this now. Also, I don't fully understand how you did this with your for loops and `@eval` (but it looks clean)
- Because some functions are missing, a lot of your JET tests are failing. I was not able to determine whether adding the missing functions for Transposed and Adjoint matrices will solve all these issues or if there are actual issues with the current code (regarding JET). The basic test `JET.test_package(DeviceSparseArrays; target_defined_modules = true)` passes.
- It's currently not possible to do `c = A * b` (but `mul!(c, A, b)` works just fine), I'm not used to defining new methods for Base functions, I'm sure its just a small thing missing somewhere but I couldn't find it.

Finally, I recently started to play around with the idea of **permuting rows** in sparse matrices to "group" together rows according to the number of non-zeros. This functionality is **implemented** for SELL matrices **but not used**  as I still need to figure out a clean and user friendly way to integrate the feature. For now, the constructor can permute the rows as it constructs the matrix, and use the `perm` field in the struct to save the permutation that was performed. This allows the user to apply the same permutation on their other arrays. It"s not super user-friendly, it might be possible to create a `Permuted` wrapper similar to the how `Transpose` is usually managed but I haven't tried.